### PR TITLE
Fonctionnalité : commande /report bot telegram

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,8 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+
+#scans 
+scans/*
+nmap_results.txt

--- a/README.md
+++ b/README.md
@@ -6,7 +6,19 @@ git clone https://github.com/m1d0b4n/t3leserv.git && cd t3leserv
 ```
 1️⃣
 
+<<<<<<< HEAD
 Edit the .env file with your correct data.
+=======
+- `TELEGRAM_BOT_TOKEN` : Votre token pour l'API de telegram généré par @BotFather
+
+- `PROXY_URL` : Si le serveur est deployé dérrière un proxy, l'URL finale doit être paramètré avec ce variable
+
+- `CHAT_ID` : L'ID du chat à envoyer le rapport
+
+- `PORT` : Le port de démarrage du serveur Express
+
+- `REDIRECT_URL` : L'URL de redirection pour le ressource  `/track`
+>>>>>>> 60c388d (Ajout commande /report au bot telegram)
 
 2️⃣
 ```


### PR DESCRIPTION
Ce commit ajoute la commande `/report` au bot telegram avec deux options :

- Analyser l'IP actuelle
- Analyser autre IP

<img width="518" alt="image" src="https://github.com/user-attachments/assets/d1602902-bd18-4430-aaaa-5dd129f0324b" />

*Option analyser l'IP actuelle*

Demande à l'utilisateur de visiter un lien pour capturer son IP pour après générer et envoyer le rapport

<img width="518" alt="image" src="https://github.com/user-attachments/assets/5d6d3e26-6336-4a62-ac8a-43a0f525b925" />

*Option analyser autre IP*

Demande à l'utilisateur envoyer un IP pour générer et envoyer le rapport

<img width="518" alt="image" src="https://github.com/user-attachments/assets/1718500c-04a1-4d47-9be1-f55589fe2d87" />


